### PR TITLE
Fix quick toggle button in 0.8.5

### DIFF
--- a/dist/TrueRNG.js
+++ b/dist/TrueRNG.js
@@ -383,7 +383,7 @@ Hooks.once('init', () => {
     // Debug.GroupEnd();
 });
 // have to use ready in order for the query selectors to work.
-Hooks.once('ready', () => {
+Hooks.once("renderChatLog", () => {
     let enabled = true;
     try {
         // some big brained module maker thinks it's a good idea to call the ready hook before the game is actually ready.

--- a/module.json
+++ b/module.json
@@ -2,10 +2,10 @@
 	"name": "truerng",
 	"title": "True RNG",
 	"description": "Replaces the default random number generator with api calls to random.org. Providing truly random dice rolls. API Key Needed.",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"author": "KiD Fearless",
 	"minimumCoreVersion": "0.7.9",
-	"compatibleCoreVersion": "0.7.9",
+	"compatibleCoreVersion": "0.8.5",
 	"esmodules": [
 		"dist/TrueRNG.js"
 	],
@@ -13,5 +13,5 @@
 	"bugs": "https://github.com/kidfearless/Foundry-TrueRNG/issues",
 	"url": "https://github.com/kidfearless/Foundry-TrueRNG",
 	"manifest": "https://raw.githubusercontent.com/kidfearless/Foundry-TrueRNG/master/module.json",
-	"download": "https://github.com/kidfearless/Foundry-TrueRNG/archive/refs/tags/v1.0.5.zip"
+	"download": "https://github.com/kidfearless/Foundry-TrueRNG/archive/refs/tags/v1.0.6.zip"
 }

--- a/src/TrueRNG.ts
+++ b/src/TrueRNG.ts
@@ -561,8 +561,7 @@ Hooks.once('init', () =>
 	// Debug.GroupEnd();
 });
 
-// have to use ready in order for the query selectors to work.
-// ready didn't have it ready in 0.8.x so now we use renderChatLog 
+// have to use ready in order for the query selectors to work... ready didn't have it ready in 0.8.x so now we use renderChatLog
 Hooks.once("renderChatLog", () =>
 {
 	let enabled = true;

--- a/src/TrueRNG.ts
+++ b/src/TrueRNG.ts
@@ -562,7 +562,8 @@ Hooks.once('init', () =>
 });
 
 // have to use ready in order for the query selectors to work.
-Hooks.once('ready', () =>
+// ready didn't have it ready in 0.8.x so now we use renderChatLog 
+Hooks.once("renderChatLog", () =>
 {
 	let enabled = true;
 	try


### PR DESCRIPTION
The hook for inserting the quick toggle button has been moved to "renderChatLog" in order to ensure the dom is fully ready for what we need.

changes were done by hand until source mappings can be updated.